### PR TITLE
Remove protocol from font asset urls

### DIFF
--- a/hubpress/index.html
+++ b/hubpress/index.html
@@ -11,8 +11,8 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
         <style type="text/css">@import url(//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css);</style>
-        <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,500' rel='stylesheet' type='text/css'>
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Roboto:400,300,500' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
         <link rel="stylesheet" href="styles/main.css">
 

--- a/hubpress/styles/blog.css
+++ b/hubpress/styles/blog.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Raleway:400,700|Roboto+Slab:300,400);
+@import url(//fonts.googleapis.com/css?family=Raleway:400,700|Roboto+Slab:300,400);
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */


### PR DESCRIPTION
When loading the admin view from an `https` url front assets are blocked from being loaded. Removing the `http:` from the asset urls corrects this.

# Screenshot

![screen shot 2015-02-10 at 10 36 28 am](https://cloud.githubusercontent.com/assets/172217/6133706/b6145d12-b110-11e4-9579-7031f09c89b4.png)
