### PR TITLE
remove "read more" link at footer of post in Casper theme, take two

### DIFF
--- a/themes/Casper/post.hbs
+++ b/themes/Casper/post.hbs
@@ -44,8 +44,6 @@
 
                 {{#if bio}}
                     <p>{{bio}}</p>
-                {{else}}
-                    <p>Read <a href="{{url}}">more posts</a> by this author.</p>
                 {{/if}}
                 <div class="author-meta">
                     {{#if location}}<span class="author-location icon-location">{{location}}</span>{{/if}}


### PR DESCRIPTION
It currently links to the URL of the post you're already reading.

This just removes that particular sentence, but leaves the other links using the `url` variable.

(redo of #227)
